### PR TITLE
Document siwe-django in the Python library docs

### DIFF
--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -510,6 +510,7 @@ issued_at = ISO8601Datetime.from_datetime(datetime.now(tz=timezone.utc))
 
 -   **GitHub**: [signinwithethereum/siwe-py](https://github.com/signinwithethereum/siwe-py)
 -   **PyPI**: [signinwithethereum](https://pypi.org/project/signinwithethereum/)
+-   **Django**: [signinwithethereum/siwe-django](https://github.com/signinwithethereum/siwe-django)
 -   **EIP-4361**: [Sign in with Ethereum specification](https://eips.ethereum.org/EIPS/eip-4361)
 
 ---

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -349,7 +349,7 @@ def verify():
 
 ## Django (`signinwithethereum/siwe-django`)
 
-For full-stack Django projects, the official `siwe-django` package wraps `signinwithethereum` with a complete nonce-based login flow, session authentication, a pluggable auth backend, wallet-linking for existing users, and optional Django REST Framework views.
+`siwe-django` is a reusable Django app built on `signinwithethereum`. It exposes nonce / verify / session endpoints, plugs into `django.contrib.auth` via a `SiweBackend`, and adds models for linking wallets to existing users — with an optional Django REST Framework variant.
 
 <FullWidthLink
 	href='https://github.com/signinwithethereum/siwe-django'
@@ -367,13 +367,13 @@ pip install siwe-django
 Optional extras:
 
 - `siwe-django[drf]` — Django REST Framework views and serializers
-- `siwe-django[drf,openapi]` — auto-generated OpenAPI schemas
+- `siwe-django[drf,openapi]` — auto-generated OpenAPI schemas for the DRF views
 - `siwe-django[redis]` — Redis-backed nonce store
 - `siwe-django[cli]` — interactive setup wizard
 
 ### Setup
 
-Add the app and auth backend to your Django settings:
+Add the app and the `SiweBackend` to your settings:
 
 ```python
 INSTALLED_APPS = [
@@ -389,7 +389,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 ```
 
-Configure SIWE behaviour via the `SIWE_DJANGO` settings dict:
+Configure the message under `SIWE_DJANGO`:
 
 ```python
 SIWE_DJANGO = {
@@ -406,7 +406,7 @@ SIWE_DJANGO = {
 
 `RPC_URLS` enables EIP-1271 / EIP-6492 verification for smart contract wallets on the listed chains.
 
-Mount the URLs and run migrations:
+Mount the URLs and run the migrations:
 
 ```python
 # urls.py
@@ -414,7 +414,7 @@ from django.urls import include, path
 
 urlpatterns = [
     path("auth/siwe/", include("siwe_django.urls")),
-    # Optional: DRF-flavoured routes
+    # Optional: DRF-flavored routes
     path("api/auth/siwe/", include("siwe_django.drf.urls")),
 ]
 ```
@@ -425,23 +425,23 @@ python manage.py migrate
 
 ### Endpoints
 
-Mounting `siwe_django.urls` exposes:
+`siwe_django.urls` exposes:
 
-| Method   | Path                         | Description                                                               |
-| -------- | ---------------------------- | ------------------------------------------------------------------------- |
-| `GET`    | `/nonce/`                    | Issues a single-use nonce plus message metadata (domain, URI, statement). |
-| `POST`   | `/verify/`                   | Verifies a `{ message, signature }` body and creates a Django session.    |
-| `GET`    | `/me/`                       | Returns the currently authenticated SIWE identity.                        |
-| `POST`   | `/logout/`                   | Destroys the Django session.                                              |
-| `POST`   | `/link/`                     | Links another verified wallet to the current user.                        |
-| `GET`    | `/wallets/`                  | Lists wallets linked to the current user.                                 |
-| `DELETE` | `/wallets/<id>/`             | Unlinks a wallet from the current user.                                   |
-| `POST`   | `/reauth/`                   | Step-up re-verification for sensitive actions.                            |
-| `GET`    | `/profile/<address-or-ens>/` | Proxies Ethereum Identity Kit profile data.                               |
+| Method   | Path                         | Description                                                                        |
+| -------- | ---------------------------- | ---------------------------------------------------------------------------------- |
+| `GET`    | `/nonce/`                    | Issues a single-use nonce alongside the message metadata (domain, URI, statement). |
+| `POST`   | `/verify/`                   | Verifies a `{ message, signature }` body and starts a Django session.              |
+| `GET`    | `/me/`                       | Returns the currently authenticated SIWE identity.                                 |
+| `POST`   | `/logout/`                   | Destroys the Django session.                                                       |
+| `POST`   | `/link/`                     | Links another verified wallet to the current user.                                 |
+| `GET`    | `/wallets/`                  | Lists the wallets linked to the current user.                                      |
+| `DELETE` | `/wallets/<id>/`             | Unlinks a wallet from the current user.                                            |
+| `POST`   | `/reauth/`                   | Re-verifies a signature for step-up authentication.                                |
+| `GET`    | `/profile/<address-or-ens>/` | Proxies Ethereum Identity Kit profile data.                                        |
 
 ### User model
 
-By default, `siwe-django` links wallets to your existing `AUTH_USER_MODEL` via the `SiweWallet` model — sign-in finds or creates a Django user and attaches the verified wallet.
+By default, `siwe-django` links wallets to your existing `AUTH_USER_MODEL` through the `SiweWallet` model — the verify endpoint finds or creates a Django user and attaches the verified wallet.
 
 For wallet-native projects, set `AUTH_USER_MODEL = "siwe_django.EthereumUser"` **before your first migration** to use the bundled user model that keys identity by Ethereum address.
 
@@ -451,9 +451,9 @@ Notable keys under `SIWE_DJANGO`:
 
 | Key                  | Default | Description                                                               |
 | -------------------- | ------- | ------------------------------------------------------------------------- |
-| `NONCE_TTL_SECONDS`  | `300`   | Nonce lifetime.                                                           |
-| `CLOCK_SKEW_SECONDS` | `60`    | Tolerance for `expiration_time` / `not_before` checks.                    |
-| `AUTO_CREATE_USERS`  | `True`  | Create a Django user on first sign-in for a new wallet.                   |
+| `NONCE_TTL_SECONDS`  | `300`   | How long an issued nonce remains valid.                                   |
+| `CLOCK_SKEW_SECONDS` | `60`    | Tolerance for `expiration_time` and `not_before` checks.                  |
+| `AUTO_CREATE_USERS`  | `True`  | Create a Django user the first time a new wallet signs in.                |
 | `RATE_LIMITS`        | `{}`    | Per-view rate limits, e.g. `{"verify": "5/m"}`.                           |
 | `AUDIT_ENABLED`      | `True`  | Persist sign-in events to the `SiweAuthEvent` model.                      |
 | `NONCE_STORE`        | `"db"`  | Switch to `"redis"` with the `redis` extra.                               |

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -347,6 +347,120 @@ def verify():
     return jsonify({"address": message.address})
 ```
 
+## Django (`signinwithethereum/siwe-django`)
+
+For full-stack Django projects, the official `siwe-django` package wraps `signinwithethereum` with a complete nonce-based login flow, session authentication, a pluggable auth backend, wallet-linking for existing users, and optional Django REST Framework views.
+
+<FullWidthLink
+	href='https://github.com/signinwithethereum/siwe-django'
+	logo='/img/github.svg'
+	text='signinwithethereum/siwe-django'
+	themeAware={true}
+/>
+
+### Installation
+
+```bash
+pip install siwe-django
+```
+
+Optional extras:
+
+- `siwe-django[drf]` — Django REST Framework views and serializers
+- `siwe-django[drf,openapi]` — auto-generated OpenAPI schemas
+- `siwe-django[redis]` — Redis-backed nonce store
+- `siwe-django[cli]` — interactive setup wizard
+
+### Setup
+
+Add the app and auth backend to your Django settings:
+
+```python
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "siwe_django",
+]
+
+AUTHENTICATION_BACKENDS = [
+    "siwe_django.backend.SiweBackend",
+    "django.contrib.auth.backends.ModelBackend",
+]
+```
+
+Configure SIWE behaviour via the `SIWE_DJANGO` settings dict:
+
+```python
+SIWE_DJANGO = {
+    "DOMAIN": "example.com",
+    "URI": "https://example.com/",
+    "STATEMENT": "Sign in with Ethereum.",
+    "ALLOWED_CHAIN_IDS": [1, 11155111],
+    "RPC_URLS": {
+        1: "https://mainnet.infura.io/v3/...",
+        11155111: "https://sepolia.infura.io/v3/...",
+    },
+}
+```
+
+`RPC_URLS` enables EIP-1271 / EIP-6492 verification for smart contract wallets on the listed chains.
+
+Mount the URLs and run migrations:
+
+```python
+# urls.py
+from django.urls import include, path
+
+urlpatterns = [
+    path("auth/siwe/", include("siwe_django.urls")),
+    # Optional: DRF-flavoured routes
+    path("api/auth/siwe/", include("siwe_django.drf.urls")),
+]
+```
+
+```bash
+python manage.py migrate
+```
+
+### Endpoints
+
+Mounting `siwe_django.urls` exposes:
+
+| Method   | Path                         | Description                                                               |
+| -------- | ---------------------------- | ------------------------------------------------------------------------- |
+| `GET`    | `/nonce/`                    | Issues a single-use nonce plus message metadata (domain, URI, statement). |
+| `POST`   | `/verify/`                   | Verifies a `{ message, signature }` body and creates a Django session.    |
+| `GET`    | `/me/`                       | Returns the currently authenticated SIWE identity.                        |
+| `POST`   | `/logout/`                   | Destroys the Django session.                                              |
+| `POST`   | `/link/`                     | Links another verified wallet to the current user.                        |
+| `GET`    | `/wallets/`                  | Lists wallets linked to the current user.                                 |
+| `DELETE` | `/wallets/<id>/`             | Unlinks a wallet from the current user.                                   |
+| `POST`   | `/reauth/`                   | Step-up re-verification for sensitive actions.                            |
+| `GET`    | `/profile/<address-or-ens>/` | Proxies Ethereum Identity Kit profile data.                               |
+
+### User model
+
+By default, `siwe-django` links wallets to your existing `AUTH_USER_MODEL` via the `SiweWallet` model — sign-in finds or creates a Django user and attaches the verified wallet.
+
+For wallet-native projects, set `AUTH_USER_MODEL = "siwe_django.EthereumUser"` **before your first migration** to use the bundled user model that keys identity by Ethereum address.
+
+### Configuration
+
+Notable keys under `SIWE_DJANGO`:
+
+| Key                  | Default | Description                                                               |
+| -------------------- | ------- | ------------------------------------------------------------------------- |
+| `NONCE_TTL_SECONDS`  | `300`   | Nonce lifetime.                                                           |
+| `CLOCK_SKEW_SECONDS` | `60`    | Tolerance for `expiration_time` / `not_before` checks.                    |
+| `AUTO_CREATE_USERS`  | `True`  | Create a Django user on first sign-in for a new wallet.                   |
+| `RATE_LIMITS`        | `{}`    | Per-view rate limits, e.g. `{"verify": "5/m"}`.                           |
+| `AUDIT_ENABLED`      | `True`  | Persist sign-in events to the `SiweAuthEvent` model.                      |
+| `NONCE_STORE`        | `"db"`  | Switch to `"redis"` with the `redis` extra.                               |
+| `TOKEN_GATES`        | —       | Sync Django groups from on-chain holdings (ERC-721 / ERC-20 / EFP / ENS). |
+
+See the [project README](https://github.com/signinwithethereum/siwe-django) for the full configuration reference, DRF integration details, and frontend wiring examples.
+
 ## Advanced
 
 ### Strict Mode

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -414,13 +414,19 @@ from django.urls import include, path
 
 urlpatterns = [
     path("auth/siwe/", include("siwe_django.urls")),
-    # Optional: DRF-flavored routes
-    path("api/auth/siwe/", include("siwe_django.drf.urls")),
 ]
 ```
 
 ```bash
 python manage.py migrate
+```
+
+If you installed the `[drf]` extra, mount the DRF routes alongside them:
+
+```python
+urlpatterns += [
+    path("api/auth/siwe/", include("siwe_django.drf.urls")),
+]
 ```
 
 ### Endpoints

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -462,7 +462,7 @@ Notable keys under `SIWE_DJANGO`:
 | `AUTO_CREATE_USERS`  | `True`  | Create a Django user the first time a new wallet signs in.                |
 | `RATE_LIMITS`        | `{}`    | Per-view rate limits, e.g. `{"verify": "5/m"}`.                           |
 | `AUDIT_ENABLED`      | `True`  | Persist sign-in events to the `SiweAuthEvent` model.                      |
-| `NONCE_STORE`        | `"db"`  | Switch to `"redis"` with the `redis` extra.                               |
+| `NONCE_STORE`        | `"siwe_django.nonce_store.DjangoOrmNonceStore"` | Dotted import path for the nonce-store class. Switch to `"siwe_django.nonce_store.RedisNonceStore"` with the `redis` extra. |
 | `TOKEN_GATES`        | —       | Sync Django groups from on-chain holdings (ERC-721 / ERC-20 / EFP / ENS). |
 
 See the [project README](https://github.com/signinwithethereum/siwe-django) for the full configuration reference, DRF integration details, and frontend wiring examples.

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -347,7 +347,7 @@ def verify():
     return jsonify({"address": message.address})
 ```
 
-## Django (`signinwithethereum/siwe-django`)
+### Django (`siwe-django`)
 
 `siwe-django` is a reusable Django app built on `signinwithethereum`. It exposes nonce / verify / session endpoints, plugs into `django.contrib.auth` via a `SiweBackend`, and adds models for linking wallets to existing users — with an optional Django REST Framework variant.
 
@@ -358,7 +358,7 @@ def verify():
 	themeAware={true}
 />
 
-### Installation
+#### Installation
 
 ```bash
 pip install siwe-django
@@ -371,7 +371,7 @@ Optional extras:
 - `siwe-django[redis]` — Redis-backed nonce store
 - `siwe-django[cli]` — interactive setup wizard
 
-### Setup
+#### Setup
 
 Add the app and the `SiweBackend` to your settings:
 
@@ -429,7 +429,7 @@ urlpatterns += [
 ]
 ```
 
-### Endpoints
+#### Endpoints
 
 `siwe_django.urls` exposes:
 
@@ -445,13 +445,13 @@ urlpatterns += [
 | `POST`   | `/reauth/`                   | Re-verifies a signature for step-up authentication.                                |
 | `GET`    | `/profile/<address-or-ens>/` | Proxies Ethereum Identity Kit profile data.                                        |
 
-### User model
+#### User model
 
 By default, `siwe-django` links wallets to your existing `AUTH_USER_MODEL` through the `SiweWallet` model — the verify endpoint finds or creates a Django user and attaches the verified wallet.
 
 For wallet-native projects, set `AUTH_USER_MODEL = "siwe_django.EthereumUser"` **before your first migration** to use the bundled user model that keys identity by Ethereum address.
 
-### Configuration
+#### Configuration
 
 Notable keys under `SIWE_DJANGO`:
 

--- a/docs/libraries/python.mdx
+++ b/docs/libraries/python.mdx
@@ -462,7 +462,7 @@ Notable keys under `SIWE_DJANGO`:
 | `AUTO_CREATE_USERS`  | `True`  | Create a Django user the first time a new wallet signs in.                |
 | `RATE_LIMITS`        | `{}`    | Per-view rate limits, e.g. `{"verify": "5/m"}`.                           |
 | `AUDIT_ENABLED`      | `True`  | Persist sign-in events to the `SiweAuthEvent` model.                      |
-| `NONCE_STORE`        | `"siwe_django.nonce_store.DjangoOrmNonceStore"` | Dotted import path for the nonce-store class. Switch to `"siwe_django.nonce_store.RedisNonceStore"` with the `redis` extra. |
+| `NONCE_STORE`        | `siwe_django.nonce_store.DjangoOrmNonceStore` | Dotted import path for the nonce-store class. Switch to `siwe_django.nonce_store.RedisNonceStore` with the `[redis]` extra. |
 | `TOKEN_GATES`        | —       | Sync Django groups from on-chain holdings (ERC-721 / ERC-20 / EFP / ENS). |
 
 See the [project README](https://github.com/signinwithethereum/siwe-django) for the full configuration reference, DRF integration details, and frontend wiring examples.


### PR DESCRIPTION
## Summary

Adds a new `## Django (signinwithethereum/siwe-django)` section to `docs/libraries/python.mdx` covering installation (with the four optional extras), settings + `SiweBackend` wiring, URL mounting (the DRF route is gated behind the `[drf]` extra in its own snippet), the endpoint table, the `SiweWallet` vs `siwe_django.EthereumUser` note, and a notable-keys configuration table — including `NONCE_STORE` documented as the full dotted import path that `import_string()` actually accepts. Also adds a `**Django**` bullet to the Python page's Resources list pointing at the `signinwithethereum/siwe-django` repo.